### PR TITLE
Support user hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,84 @@ This process will:
 - GitLab
 
 
+## Gitask Hooks
+Gitask supports pre and post hooks for specific actions.<br>
+These hooks allow you to execute custom scripts before or after an action is performed. This can be useful for automating additional custom actions.<br>
+**Note:** The 'configure' command does not support hooks.
+
+Hooks are automatically executed by Gitask when the corresponding action is performed. If a hook script fails, the action will stop, and an error message will be displayed
+
+### Configuring Hooks
+Hooks can be configured in the Gitask configuration file. Each action can have a *pre* and/or *post* hook defined.
+
+Configuration example:
+```json
+{
+  "pmt-type": "jira",
+  "vcs-type": "gitlab",
+  ...,
+  "hooks": {
+    "open": {
+      "pre": "/path/to/pre_open_hook.sh",
+      "post": "/path/to/post_open_hook.py"
+    },
+    "submit-to-review": {
+      "pre": "/path/to/pre_submit_hook.sh",
+      "post": "/path/to/post_submit_hook.py"
+    }
+  }
+}
+```
+
+### Hook script
+The hook script can be either a python or a bash **executable** script.
+The arguments passed to the sscripts are:
+- --pmt-url: The project management tool URL.
+- --pmt-token: The authentication token for the project management tool.
+- --git-url: The Git repository URL.
+- --git-token: The authentication token for the Git repository.
+- --issue-key: The current issue key.
+
+### Examples:
+#### Python
+```python
+import argparse
+
+if __name__ == "__main__":
+   parser = argparse.ArgumentParser()
+   parser.add_argument("--pmt-url")
+   parser.add_argument("--pmt-token")
+   parser.add_argument("--git-url")
+   parser.add_argument("--git-token")
+   parser.add_argument("--phase")
+   parser.add_argument("--action")
+   
+   args = parser.parse_args()
+   
+   print(f"Running {args.phase} hook for action '{args.action}'")
+   print(f"PMT URL: {args.pmt_url}")
+   print(f"GIT URL: {args.git_url}")
+```
+#### Bash
+```bash
+#!/bin/bash
+for arg in "$@"; do
+  case $arg in
+    --pmt-url=*)
+      PMT_URL="${arg#*=}"
+      ;;
+    --pmt-token=*)
+      PMT_TOKEN="${arg#*=}"
+      ;;
+  esac
+done
+
+echo "Pre-hook for 'open' action triggered."
+echo "PMT URL: $PMT_URL"
+echo "Issue Key: $1"
+```
+
+
 ## Issue ID Extraction
 
 The current-ticket script should:

--- a/gitask/config/config.py
+++ b/gitask/config/config.py
@@ -19,6 +19,7 @@ class Config:
     REVIEWER_FIELD_PROP_NAME = "reviewer-field"
     GIT_BRANCH_FIELD_PROP_NAME = "git-branch-field"
     CURRENT_TICKET_PROP_NAME = "current-ticket"
+    HOOKS_PROP_NAME = "hooks"
 
 
     _instance = None
@@ -98,3 +99,7 @@ class Config:
     @property
     def current_ticket_script(self):
         return self.config_data.get(Config.CURRENT_TICKET_PROP_NAME)
+
+    @property
+    def hooks(self):
+        return self.config_data.get(Config.HOOKS_PROP_NAME)


### PR DESCRIPTION
Users can now define custom scripts that run automatically before or after specific Gitask commands.
To configure these hooks, add a "pre" and/or "post" entry under the hooks section of your config.json, specifying the path to the script you want to execute.
Both Python and shell scripts are supported.

When executed, each script will receive the following parameters from Gitask:
	•	--pmt-url: URL of the project management tool (e.g., Jira)
	•	--pmt-token: Authentication token for the PMT
	•	--git-url: URL of the version control system (e.g., GitLab)
	•	--git-token: Authentication token for the VCS
	•	--get-current-branch: Path to the script that retrieves the current Git branch

This allows your hook scripts to access the same authenticated context as Gitask itself.